### PR TITLE
修复了异常逃逸导致结果判断错误

### DIFF
--- a/src/main/java/com/github/hcsp/MultiThreadServiceDataProcessor.java
+++ b/src/main/java/com/github/hcsp/MultiThreadServiceDataProcessor.java
@@ -3,12 +3,22 @@ package com.github.hcsp;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
+/**
+ * 这个类的bug来源于多线程对异常的处理机制。
+ * 某一个子线程出现了异常但是没有被捕获的话不会被外面的主线程捕获到，从而造成异常逃逸。
+ *
+ * 解决方法;
+ *   使用Thread.setUncaughtExceptionHandler(),从外部捕获逃逸出来的异常。
+ */
 public class MultiThreadServiceDataProcessor {
     // 线程数量
     private final int threadNumber;
     // 处理数据的远程服务
     private final RemoteService remoteService;
+    // 处理次数
+    private final AtomicInteger resultCount = new AtomicInteger();
 
     public MultiThreadServiceDataProcessor(int threadNumber, RemoteService remoteService) {
         this.threadNumber = threadNumber;
@@ -18,6 +28,7 @@ public class MultiThreadServiceDataProcessor {
     // 将所有数据发送至远程服务处理。若所有数据都处理成功（没有任何异常抛出），返回true；
     // 否则只要有任何异常产生，返回false
     public boolean processAllData(List<Object> allData) {
+        resultCount.getAndSet(0);
         int groupSize =
                 allData.size() % threadNumber == 0
                         ? allData.size() / threadNumber
@@ -27,7 +38,16 @@ public class MultiThreadServiceDataProcessor {
         try {
             List<Thread> threads = new ArrayList<>();
             for (List<Object> dataGroup : dataGroups) {
-                Thread thread = new Thread(() -> dataGroup.forEach(remoteService::processData));
+                Thread thread = new Thread(() -> {
+                    for (Object o : dataGroup) {
+                        remoteService.processData(o);
+                        resultCount.incrementAndGet();
+                    }
+                });
+                // 捕获到了任何异常就代表本次处理失败
+                thread.setUncaughtExceptionHandler((t, e) -> {
+                    System.out.println("线程<" + t.getName() + ">处理任务失败，catch：" + e.getMessage());
+                });
                 thread.start();
                 threads.add(thread);
             }
@@ -35,9 +55,11 @@ public class MultiThreadServiceDataProcessor {
             for (Thread thread : threads) {
                 thread.join();
             }
-            return true;
+
         } catch (Exception e) {
+            e.printStackTrace();
             return false;
         }
+        return resultCount.get() == allData.size();
     }
 }


### PR DESCRIPTION
我们期望发生异常时，`try-catch`机制能够捕获，然后告诉我们处理错误返回`false`。遗憾的是如果子线程中发生异常且没有被捕获的话是不会被外面的主线程捕获到的，从而造成异常逃逸。因此我们需要调用Thread的`setUncaughtExceptionHandler`来捕获逃逸掉的异常。

我给出的想法是用一个AtomicInteger实例来保存我们线程正确处理的次数，只有任务被成功执行后，次数加一，在最后我们只需要判断处理的次数是否与传入任务数量相等即可。

<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

