### PR TITLE
使用 Executors.newFixedThreadPool 代替 Thread，从而使用 Callable 代替 Runnable

### DIFF
--- a/src/main/java/com/github/hcsp/MultiThreadServiceDataProcessor.java
+++ b/src/main/java/com/github/hcsp/MultiThreadServiceDataProcessor.java
@@ -45,7 +45,7 @@ public class MultiThreadServiceDataProcessor {
         private final List<Object> data;
         private final RemoteService remoteService;
 
-        public Temp(List<Object> data, RemoteService remoteService) {
+        Temp(List<Object> data, RemoteService remoteService) {
             this.data = data;
             this.remoteService = remoteService;
         }

--- a/src/main/java/com/github/hcsp/MultiThreadServiceDataProcessor.java
+++ b/src/main/java/com/github/hcsp/MultiThreadServiceDataProcessor.java
@@ -1,8 +1,12 @@
 package com.github.hcsp;
 
 import com.google.common.collect.Lists;
-import java.util.ArrayList;
+
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 public class MultiThreadServiceDataProcessor {
     // 线程数量
@@ -23,21 +27,33 @@ public class MultiThreadServiceDataProcessor {
                         ? allData.size() / threadNumber
                         : allData.size() / threadNumber + 1;
         List<List<Object>> dataGroups = Lists.partition(allData, groupSize);
+        ExecutorService executorService = Executors.newFixedThreadPool(dataGroups.size());
 
         try {
-            List<Thread> threads = new ArrayList<>();
             for (List<Object> dataGroup : dataGroups) {
-                Thread thread = new Thread(() -> dataGroup.forEach(remoteService::processData));
-                thread.start();
-                threads.add(thread);
+                Future<Object> submit = executorService.submit(new Temp(dataGroup, remoteService));
+                submit.get();
             }
 
-            for (Thread thread : threads) {
-                thread.join();
-            }
             return true;
         } catch (Exception e) {
             return false;
+        }
+    }
+
+    private static class Temp implements Callable<Object> {
+        private final List<Object> data;
+        private final RemoteService remoteService;
+
+        public Temp(List<Object> data, RemoteService remoteService) {
+            this.data = data;
+            this.remoteService = remoteService;
+        }
+
+        @Override
+        public Object call() {
+            data.forEach(remoteService::processData);
+            return null;
         }
     }
 }


### PR DESCRIPTION
使用 Callable 代替 Runnable，从而使得线程内执行方法可以抛出错误

<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

